### PR TITLE
Updating base_estimator in utilities.py after deprecation of attribute in sklearn

### DIFF
--- a/auto_shap/utilities.py
+++ b/auto_shap/utilities.py
@@ -53,7 +53,7 @@ def determine_model_qualities(model: callable, linear_model: bool = None, tree_m
     if not calibrated_model:
         calibrated_model = determine_if_name_in_object('calibrated', model)
     if calibrated_model:
-        model = model.calibrated_classifiers_[0].base_estimator
+        model = model.calibrated_classifiers_[0].estimator
     if not linear_model:
         linear_model = determine_if_any_name_in_object(LINEAR_MODEL_NAMES, model)
     if not tree_model:


### PR DESCRIPTION
The base_estimator property has since been deprecated in current versions of sklearn, so it throws an error on newer versions of sklearn -- this deprecation can be seen here: https://scikit-learn.org/stable/modules/generated/sklearn.calibration.CalibratedClassifierCV.html

For example, I cannot share the all the portions of the error trace but the following is the relevant portion of the error:

```
Traceback (most recent call last):
  File "/.../scripts/autoshaptest.py", line 21, in <module>
    produce_shap_values_and_summary_plots(model=clf, x_df=wide[features], save_path='../shap_results')
    
  File "/.../auto_shap/auto_shap.py", line 365, in produce_shap_values_and_summary_plots
    shap_values_df, shap_expected_value, global_shap_df = generate_shap_values(
    
  File "/../auto_shap/auto_shap.py", line 310, in generate_shap_values
    determine_model_qualities(
    
  File "/.../auto_shap/utilities.py", line 56, in determine_model_qualities
    model = model.calibrated_classifiers_[0].base_estimator

AttributeError: '_CalibratedClassifier' object has no attribute 'base_estimator'
```    

This is a very cool package, thank you for making it!!